### PR TITLE
added special treatment for Netflix

### DIFF
--- a/plugin/js/content.js
+++ b/plugin/js/content.js
@@ -146,27 +146,27 @@ function fireEventNetflix(event) {
   recievedEvent = event.type;
   switch (event.type) {
     case 'play': {
-      sendEventNetflix({
+      window.postMessage({
         "action": "seek",
         "time": event.currentTime
       });
-      sendEventNetflix({
+      window.postMessage({
         "action": "play"
       });
       break;
     }
     case 'pause': {
-      sendEventNetflix({
+      window.postMessage({
         "action": "pause"
       });
-      sendEventNetflix({
+      window.postMessage({
         "action": "seek",
         "time": event.currentTime
       });
       break;
     }
     case 'seeked': {
-      sendEventNetflix({
+      window.postMessage({
         "action": "seek",
         "time": event.currentTime
       });
@@ -174,20 +174,13 @@ function fireEventNetflix(event) {
     }
     case 'ratechange': {
       console.log("content.js: setting playbackRate to " + event.playbackRate);
-      sendEventNetflix({
+      window.postMessage({
         "action": "setPlaybackRate",
         "playbackRate": event.playbackRate
       })
       break;
     }
   }
-}
-
-function sendEventNetflix(data) {
-  // send a command to netflix.js
-  document.dispatchEvent(new CustomEvent('syncwatchExtension', {
-    detail: data
-  }));
 }
 
 init();

--- a/plugin/js/content.js
+++ b/plugin/js/content.js
@@ -111,8 +111,6 @@ function isNetflix() {
 }
 
 function fireEventNetflix(event) {
-  recieved = true;
-  recievedEvent = event.type;
   switch (event.type) {
     case 'play': {
       window.postMessage({

--- a/plugin/js/content.js
+++ b/plugin/js/content.js
@@ -173,7 +173,6 @@ function fireEventNetflix(event) {
       break;
     }
     case 'ratechange': {
-      console.log("content.js: setting playbackRate to " + event.playbackRate);
       window.postMessage({
         "action": "setPlaybackRate",
         "playbackRate": event.playbackRate

--- a/plugin/js/content.js
+++ b/plugin/js/content.js
@@ -105,15 +105,62 @@ function errorOnEvent(err) {
   }
 }
 
+function isNetflix() {
+  // are we on the netflix.com page?
+  return window.location.host === 'www.netflix.com';
+}
+
+function fireEventNetflix(event) {
+  recieved = true;
+  recievedEvent = event.type;
+  switch (event.type) {
+    case 'play': {
+      window.postMessage({
+        action: 'seek',
+        time: event.currentTime,
+      });
+      window.postMessage({
+        action: 'play',
+      });
+      break;
+    }
+    case 'pause': {
+      window.postMessage({
+        action: 'pause',
+      });
+      window.postMessage({
+        action: 'seek',
+        time: event.currentTime,
+      });
+      break;
+    }
+    case 'seeked': {
+      window.postMessage({
+        action: 'seek',
+        time: event.currentTime,
+      });
+      break;
+    }
+    case 'ratechange': {
+      window.postMessage({
+        action: 'setPlaybackRate',
+        playbackRate: event.playbackRate,
+      });
+      break;
+    }
+  }
+}
+
 function fireEvent(event) {
+  recieved = true;
+  recievedEvent = event.type;
+
   // if we are on netflix.com use the custom function instead
   if (isNetflix()) {
     fireEventNetflix(event);
     return;
   }
 
-  recieved = true;
-  recievedEvent = event.type;
   switch (event.type) {
     case 'play': {
       nodes[event.element].currentTime = event.currentTime;
@@ -131,52 +178,6 @@ function fireEvent(event) {
     }
     case 'ratechange': {
       nodes[event.element].playbackRate = event.playbackRate;
-      break;
-    }
-  }
-}
-
-function isNetflix() {
-  // are we on the netflix.com page?
-  return location.host === "www.netflix.com";
-}
-
-function fireEventNetflix(event) {
-  recieved = true;
-  recievedEvent = event.type;
-  switch (event.type) {
-    case 'play': {
-      window.postMessage({
-        "action": "seek",
-        "time": event.currentTime
-      });
-      window.postMessage({
-        "action": "play"
-      });
-      break;
-    }
-    case 'pause': {
-      window.postMessage({
-        "action": "pause"
-      });
-      window.postMessage({
-        "action": "seek",
-        "time": event.currentTime
-      });
-      break;
-    }
-    case 'seeked': {
-      window.postMessage({
-        "action": "seek",
-        "time": event.currentTime
-      });
-      break;
-    }
-    case 'ratechange': {
-      window.postMessage({
-        "action": "setPlaybackRate",
-        "playbackRate": event.playbackRate
-      })
       break;
     }
   }

--- a/plugin/js/content.js
+++ b/plugin/js/content.js
@@ -106,6 +106,12 @@ function errorOnEvent(err) {
 }
 
 function fireEvent(event) {
+  // if we are on netflix.com use the custom function instead
+  if (isNetflix()) {
+    fireEventNetflix(event);
+    return;
+  }
+
   recieved = true;
   recievedEvent = event.type;
   switch (event.type) {
@@ -128,6 +134,60 @@ function fireEvent(event) {
       break;
     }
   }
+}
+
+function isNetflix() {
+  // are we on the netflix.com page?
+  return location.host === "www.netflix.com";
+}
+
+function fireEventNetflix(event) {
+  recieved = true;
+  recievedEvent = event.type;
+  switch (event.type) {
+    case 'play': {
+      sendEventNetflix({
+        "action": "seek",
+        "time": event.currentTime
+      });
+      sendEventNetflix({
+        "action": "play"
+      });
+      break;
+    }
+    case 'pause': {
+      sendEventNetflix({
+        "action": "pause"
+      });
+      sendEventNetflix({
+        "action": "seek",
+        "time": event.currentTime
+      });
+      break;
+    }
+    case 'seeked': {
+      sendEventNetflix({
+        "action": "seek",
+        "time": event.currentTime
+      });
+      break;
+    }
+    case 'ratechange': {
+      console.log("content.js: setting playbackRate to " + event.playbackRate);
+      sendEventNetflix({
+        "action": "setPlaybackRate",
+        "playbackRate": event.playbackRate
+      })
+      break;
+    }
+  }
+}
+
+function sendEventNetflix(data) {
+  // send a command to netflix.js
+  document.dispatchEvent(new CustomEvent('syncwatchExtension', {
+    detail: data
+  }));
 }
 
 init();

--- a/plugin/js/loadNetflix.js
+++ b/plugin/js/loadNetflix.js
@@ -1,0 +1,8 @@
+// used for loading netflix.js script into page header
+
+var s = document.createElement('script');
+s.src = chrome.runtime.getURL('js/netflix.js');
+s.onload = function() {
+    this.remove();
+};
+(document.head || document.documentElement).appendChild(s);

--- a/plugin/js/loadNetflix.js
+++ b/plugin/js/loadNetflix.js
@@ -1,8 +1,8 @@
 // used for loading netflix.js script into page header
 
-var s = document.createElement('script');
+const s = document.createElement('script');
 s.src = chrome.runtime.getURL('js/netflix.js');
-s.onload = function() {
-    this.remove();
+s.onload = () => {
+  this.remove();
 };
 (document.head || document.documentElement).appendChild(s);

--- a/plugin/js/netflix.js
+++ b/plugin/js/netflix.js
@@ -1,0 +1,38 @@
+// this file gets injected into <head> of netflix page
+// it allows us to interact with the window.netflix object
+
+function getPlayer() {
+    // get the netflix player object
+    const videoPlayer = netflix.appContext.state.playerApp.getAPI().videoPlayer
+
+    // Getting player id
+    const playerSessionId = videoPlayer.getAllPlayerSessionIds()[0]
+    const player = videoPlayer.getVideoPlayerBySessionId(playerSessionId)
+
+    return player;
+}
+
+document.addEventListener('syncwatchExtension', event => {
+    const player = getPlayer();
+
+    // console.log("registered event", event)
+
+    switch (event.detail.action) {
+        case "play": {
+            player.play();
+            break;
+        }
+        case "pause": {
+            player.pause();
+            break;
+        }
+        case "seek": {
+            player.seek(event.detail.time * 1000);
+            break;
+        }
+        case "setPlaybackRate": {
+            player.setPlaybackRate(event.detail.playbackRate);
+            break;
+        }
+    }
+});

--- a/plugin/js/netflix.js
+++ b/plugin/js/netflix.js
@@ -15,8 +15,6 @@ function getPlayer() {
 window.addEventListener('message', event => {
     const player = getPlayer();
 
-    // console.log("registered event", event)
-
     switch (event.data.action) {
         case "play": {
             player.play();

--- a/plugin/js/netflix.js
+++ b/plugin/js/netflix.js
@@ -2,35 +2,35 @@
 // it allows us to interact with the window.netflix object
 
 function getPlayer() {
-    // get the netflix player object
-    const videoPlayer = netflix.appContext.state.playerApp.getAPI().videoPlayer
+  // get the netflix player object
+  const { videoPlayer } = window.netflix.appContext.state.playerApp.getAPI();
 
-    // Getting player id
-    const playerSessionId = videoPlayer.getAllPlayerSessionIds()[0]
-    const player = videoPlayer.getVideoPlayerBySessionId(playerSessionId)
+  // Getting player id
+  const playerSessionId = videoPlayer.getAllPlayerSessionIds()[0];
+  const player = videoPlayer.getVideoPlayerBySessionId(playerSessionId);
 
-    return player;
+  return player;
 }
 
-window.addEventListener('message', event => {
-    const player = getPlayer();
+window.addEventListener('message', (event) => {
+  const player = getPlayer();
 
-    switch (event.data.action) {
-        case "play": {
-            player.play();
-            break;
-        }
-        case "pause": {
-            player.pause();
-            break;
-        }
-        case "seek": {
-            player.seek(event.data.time * 1000);
-            break;
-        }
-        case "setPlaybackRate": {
-            player.setPlaybackRate(event.data.playbackRate);
-            break;
-        }
+  switch (event.data.action) {
+    case 'play': {
+      player.play();
+      break;
     }
+    case 'pause': {
+      player.pause();
+      break;
+    }
+    case 'seek': {
+      player.seek(event.data.time * 1000);
+      break;
+    }
+    case 'setPlaybackRate': {
+      player.setPlaybackRate(event.data.playbackRate);
+      break;
+    }
+  }
 });

--- a/plugin/js/netflix.js
+++ b/plugin/js/netflix.js
@@ -15,7 +15,7 @@ function getPlayer() {
 window.addEventListener('message', event => {
     const player = getPlayer();
 
-    console.log("registered event", event)
+    // console.log("registered event", event)
 
     switch (event.data.action) {
         case "play": {

--- a/plugin/js/netflix.js
+++ b/plugin/js/netflix.js
@@ -12,12 +12,12 @@ function getPlayer() {
     return player;
 }
 
-document.addEventListener('syncwatchExtension', event => {
+window.addEventListener('message', event => {
     const player = getPlayer();
 
-    // console.log("registered event", event)
+    console.log("registered event", event)
 
-    switch (event.detail.action) {
+    switch (event.data.action) {
         case "play": {
             player.play();
             break;
@@ -27,11 +27,11 @@ document.addEventListener('syncwatchExtension', event => {
             break;
         }
         case "seek": {
-            player.seek(event.detail.time * 1000);
+            player.seek(event.data.time * 1000);
             break;
         }
         case "setPlaybackRate": {
-            player.setPlaybackRate(event.detail.playbackRate);
+            player.setPlaybackRate(event.data.playbackRate);
             break;
         }
     }

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -31,5 +31,12 @@
     "tabs",
     "storage",
     "notifications"
-  ]
+  ],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["js/loadNetflix.js"]
+    }
+  ],
+  "web_accessible_resources": ["js/netflix.js"]
 }

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -34,7 +34,7 @@
   ],
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
+      "matches": ["https://www.netflix.com/*"],
       "js": ["js/loadNetflix.js"]
     }
   ],


### PR DESCRIPTION
Fixes #20 

I had to add a second content script to inject `netflix.js` into the page header. This was necessary, as content scripts can't normally interact with `window` variables, so `window.netflix` was unavailable. 

Tested in Chrome and Firefox.