### PR TITLE
Initial Firefox mobile support

### DIFF
--- a/plugin/css/options.css
+++ b/plugin/css/options.css
@@ -17,3 +17,12 @@
   width: 150px;
   float: right;
 }
+
+/* adjustments for mobile devices (firefox only) */
+@supports (-moz-appearance: none) {
+  @media only screen and (hover: none) and (pointer: coarse) {
+    #main {
+      width: 100%;
+    }
+  }
+}

--- a/plugin/css/options.css
+++ b/plugin/css/options.css
@@ -22,7 +22,7 @@
 @supports (-moz-appearance: none) {
   @media only screen and (hover: none) and (pointer: coarse) {
     #main {
-      width: 100%;
+      width: 96%;
     }
   }
 }

--- a/plugin/css/ui.css
+++ b/plugin/css/ui.css
@@ -83,3 +83,18 @@ input {
   color: red;
   display: none;
 }
+
+/* adjustments for mobile devices (firefox only) */
+@supports (-moz-appearance: none) {
+  @media only screen and (hover: none) and (pointer: coarse) {
+    #main {
+      width: 96%;
+      margin: 0 auto 0 auto;
+    }
+    .block,
+    li {
+      width: 100%;
+      height: 2.5em;
+    }
+  }
+}

--- a/plugin/css/ui.css
+++ b/plugin/css/ui.css
@@ -94,6 +94,9 @@ input {
     .block,
     li {
       width: 100%;
+    }
+    input.block,
+    .button {
       height: 2.5em;
     }
   }

--- a/plugin/css/ui.css
+++ b/plugin/css/ui.css
@@ -15,7 +15,7 @@ body {
 
 #main {
   width: 240px;
-  padding: 2px;
+  padding: 2px 0 2px 0;
 }
 
 .block,

--- a/plugin/js/background.js
+++ b/plugin/js/background.js
@@ -2,6 +2,9 @@ const debug = false;
 
 const manifest = chrome.runtime.getManifest();
 const isFirefox = typeof InstallTrigger !== 'undefined';
+const isMobile =
+  window.matchMedia &&
+  window.matchMedia('only screen and (hover: none) and (pointer: coarse)').matches;
 let user = {
   name: null,
   room: null,
@@ -298,9 +301,11 @@ chrome.tabs.onActivated.addListener(() => {
   changeSyncTab();
 });
 
-chrome.windows.onFocusChanged.addListener(() => {
-  changeSyncTab();
-});
+if (!(isFirefox && isMobile)) {
+  chrome.windows.onFocusChanged.addListener(() => {
+    changeSyncTab();
+  });
+}
 
 chrome.storage.onChanged.addListener((obj) => {
   if (obj.connectionUrl) {

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "__MSG_appName__",
   "description": "__MSG_appDesc__",
-  "version": "0.411",
+  "version": "0.412",
   "default_locale": "en",
   "options_ui": {
     "page": "options.html",

--- a/plugin/options.html
+++ b/plugin/options.html
@@ -5,6 +5,7 @@
     <link rel="stylesheet" type="text/css" href="css/ui.css" />
     <link rel="stylesheet" type="text/css" href="css/options.css" />
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
   </head>
   <body>
     <div id="main">

--- a/plugin/popup.html
+++ b/plugin/popup.html
@@ -5,6 +5,7 @@
     <link rel="stylesheet" type="text/css" href="css/ui.css" />
     <link rel="stylesheet" type="text/css" href="css/popup.css" />
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
   </head>
   <body>
     <div id="main">


### PR DESCRIPTION
Potentially closes https://github.com/Semro/syncwatch/issues/24

Seems like the latest Firefox mobile doesn't have feature to open an extension popup, so for now it only works for Firefox Nightly, tested on version 99.0a1 (Build #2015865867).

Might be possible to open popup as a new tab, but it will require more workaround on how to handle sharable tab with video, as the currently opened tab will be a popup page, I personally would just wait for the next Firefox updates.

<details>
  <summary>Notes for future me on debugging an extension for Firefox mobile</summary>
  

- To inspect elements of popup.html or options.html possible only opening it in a new tab, example code for background.js:
`browser.tabs.create({url: 'popup.html'});`
- For some reason, there will be no error/warning if an extension is using unsupported API for Firefox mobile. I've managed to spot non-working code manually writing console.log in different places.

</details>
