### PR TITLE
fix: always update playback rate

### DIFF
--- a/plugin/js/content.js
+++ b/plugin/js/content.js
@@ -161,6 +161,8 @@
       return;
     }
 
+    nodes[event.element].playbackRate = event.playbackRate;
+
     switch (event.type) {
       case 'play': {
         nodes[event.element].currentTime = event.currentTime;

--- a/plugin/js/players/netflix/netflix.js
+++ b/plugin/js/players/netflix/netflix.js
@@ -15,6 +15,8 @@ function getPlayer() {
 window.addEventListener('message', (event) => {
   const player = getPlayer();
 
+  player.setPlaybackRate(event.data.playbackRate);
+
   switch (event.data.action) {
     case 'play': {
       player.play();


### PR DESCRIPTION
Fixes: https://github.com/Semro/syncwatch/issues/37
Playback rate updates on any event. 
@apmforgitissues012 it should work now with this change.
Even if other users in the room will change playback rate, then Global Speed extension will override it and rate should change to everyone in the room. BUT, if other people using Global Speed extension with other playback rate then it will infinitely send events back and forth, keep that in mind.
I made zip package, you can test it.
[syncwatch-always-update-playback-rate.zip](https://github.com/Semro/syncwatch/files/9943748/syncwatch-always-update-playback-rate.zip)
