### PR TITLE
fix: drop strict url comparison on syncing tab

### DIFF
--- a/packages/syncwatch-extension/src/js/popup.js
+++ b/packages/syncwatch-extension/src/js/popup.js
@@ -33,7 +33,7 @@ shareElement.onclick = () => {
 };
 
 sharedElement.onclick = () => {
-  chrome.tabs.create({ url: sharedElement.href });
+  chrome.runtime.sendMessage({ from: 'popupOpenVideo', url: sharedElement.href });
   return false;
 };
 


### PR DESCRIPTION
will resolve:

- https://github.com/Semro/syncwatch/issues/47
- some part of https://github.com/Semro/syncwatch/issues/6

subtasks:

- [x] keep tab in sync after reconnection
- [x] determine if user puts other url in tab then stop sync it
- [x] if other user in the room shares other url differ from inital then stop syncing tab
- [x] fix tests
- [x] add tests
   - [x] on page reload, should still sync tab
   - [x] on new url in the tab should not sync
   - [x] on clicking "disconnect" and then "connect" in popup should still sync tab
- [x] manual testing
  - [x] Firefox
  - [x] Firefox Android